### PR TITLE
Update package.json

### DIFF
--- a/packages/engine.service-web/package.json
+++ b/packages/engine.service-web/package.json
@@ -74,7 +74,7 @@
     "postcss": "^8.3.6",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.1.1",
-    "postcss-preset-env": "^6.7.0",
+    "postcss-preset-env": "^7.4.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "style-loader": "^3.2.1",


### PR DESCRIPTION
I updated a package because, we get this warning  on kip:
This version of postcss-preset-env is not optimised to work with PostCSS 8.   │
│                Please update to version 7 of PostCSS Preset Env.                │
│                                                                                 │
│                    If you find issues, you can report it at:                    │
│          https://github.com/csstools/postcss-plugins/issues/new/choose

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
